### PR TITLE
update instructions for latest `go-livepeer` using `go.mod`

### DIFF
--- a/offline.md
+++ b/offline.md
@@ -16,7 +16,7 @@ export LD_LIBRARY_PATH=/usr/local/lib/
 * Change into the `go-livepeer` directory:
 
 ```bash
-cd "$HOME/go/src/github.com/livepeer/go-livepeer"
+cd "$HOME/go-livepeer"
 ```
 
 * Start a screen session for the broadcaster:

--- a/testnet.md
+++ b/testnet.md
@@ -23,7 +23,7 @@ export LD_LIBRARY_PATH=/usr/local/lib/
 * Change into the `go-livepeer` directory:
 
 ```bash
-cd "$HOME/go/src/github.com/livepeer/go-livepeer"
+cd "$HOME/go-livepeer"
 ```
 
 * Start a screen session for the broadcaster:

--- a/ubuntu/cuda-livepeer-setup.md
+++ b/ubuntu/cuda-livepeer-setup.md
@@ -23,8 +23,9 @@ su - livepeer
 * Fetch go-livepeer using `go get`, then build livepeer and devtool:
 
 ```bash
-go get github.com/livepeer/go-livepeer/cmd/livepeer
-cd "$HOME/go/src/github.com/livepeer/go-livepeer"
+git clone https://github.com/livepeer/go-livepeer "$HOME/go-livepeer"
+cd "$HOME/go-livepeer"
+go mod download
 go build ./cmd/livepeer/livepeer.go
 go build ./cmd/devtool/devtool.go
 ```


### PR DESCRIPTION
These build instructions broke after the move to `go.mod`. This updates the setup document with the new method.