### PR TITLE
fix initializeRound flags

### DIFF
--- a/prometheus-grafana/docker-compose-b_o_t-rinkeby.yml
+++ b/prometheus-grafana/docker-compose-b_o_t-rinkeby.yml
@@ -2,7 +2,7 @@ version: '3.5'
 services:
   orchestrator:
     image: livepeer/go-livepeer:master
-    command: '-orchestrator -network rinkeby -orchSecret /secret.txt -serviceAddr orchestrator:8935 -pricePerUnit 1 -initializeRound=true -ethPassword=/root/pw.txt -cliAddr 0.0.0.0:7935 -monitor=true'
+    command: '-orchestrator -network rinkeby -orchSecret /secret.txt -serviceAddr orchestrator:8935 -pricePerUnit 1 -initializeRound -ethPassword=/root/pw.txt -cliAddr 0.0.0.0:7935 -monitor=true'
     ports:
       - 7935:7935
       - 8935:8935

--- a/prometheus-grafana/docker-compose-b_ot-rinkeby.yml
+++ b/prometheus-grafana/docker-compose-b_ot-rinkeby.yml
@@ -2,7 +2,7 @@ version: '3.5'
 services:
   orchtran:
     image: livepeer/go-livepeer:master
-    command: '-network rinkeby -orchestrator -transcoder -serviceAddr orchtran:8935 -initializeRound=true -pricePerUnit 1 -nvidia 0 -ethPassword=/root/pw.txt -cliAddr 0.0.0.0:7935 -monitor=true'
+    command: '-network rinkeby -orchestrator -transcoder -serviceAddr orchtran:8935 -initializeRound -pricePerUnit 1 -nvidia 0 -ethPassword=/root/pw.txt -cliAddr 0.0.0.0:7935 -monitor=true'
     ports:
       - 7935:7935
       - 8935:8935

--- a/systemd/README.md
+++ b/systemd/README.md
@@ -35,7 +35,7 @@ Restart=always
 RestartSec=90s
 Environment="LD_LIBRARY_PATH=/usr/local/lib/"
 WorkingDirectory=/home/livepeer/go-livepeer/
-ExecStart=/home/livepeer/go-livepeer/livepeer -network rinkeby -orchestrator -orchSecret osecret.txt -pricePerUnit 1 -initializeRound true -serviceAddr 127.0.0.1:8935 -ethPassword pw.txt
+ExecStart=/home/livepeer/go-livepeer/livepeer -network rinkeby -orchestrator -orchSecret osecret.txt -pricePerUnit 1 -initializeRound -serviceAddr 127.0.0.1:8935 -ethPassword pw.txt
 
 [Install]
 WantedBy=default.target
@@ -137,7 +137,7 @@ Restart=always
 RestartSec=90s
 Environment="LD_LIBRARY_PATH=/usr/local/lib/"
 WorkingDirectory=/home/livepeer/go-livepeer/
-ExecStart=/home/livepeer/go-livepeer/livepeer -network rinkeby -orchestrator -transcoder -pricePerUnit 1 -nvidia 0 -initializeRound true -serviceAddr 127.0.0.1:8935 -ethPassword pw.txt
+ExecStart=/home/livepeer/go-livepeer/livepeer -network rinkeby -orchestrator -transcoder -pricePerUnit 1 -nvidia 0 -initializeRound -serviceAddr 127.0.0.1:8935 -ethPassword pw.txt
 
 [Install]
 WantedBy=default.target

--- a/testnet-devtool.md
+++ b/testnet-devtool.md
@@ -77,7 +77,7 @@ For example:
     -ethUrl ws://localhost:8546/ \
     -ethPassword "" \
     -network=devenv \
-    -monitor=false -currentManifest=true -cliAddr 127.0.0.1:7936 -httpAddr 127.0.0.1:8936  -initializeRound true \
+    -monitor=false -currentManifest=true -cliAddr 127.0.0.1:7936 -httpAddr 127.0.0.1:8936  -initializeRound \
     -serviceAddr 127.0.0.1:8936  -transcoder=true -orchestrator=true \
      -ipfsPath ./.lpdev2/orchestrator_{wallet}/trans -orchSecret secre -pricePerUnit 1 -nvidia 0
 ```

--- a/testnet-rinkeby-b_o_t.md
+++ b/testnet-rinkeby-b_o_t.md
@@ -51,7 +51,7 @@ echo secret > osecret.txt
 * Run the following command to start the orchestrator:
 
 ```bash
-./livepeer -v 99 -network rinkeby -orchestrator -orchSecret osecret.txt -pricePerUnit 1 -initializeRound true -serviceAddr 127.0.0.1:8935 -orchAddr 0.0.0.0:8935
+./livepeer -v 99 -network rinkeby -orchestrator -orchSecret osecret.txt -pricePerUnit 1 -initializeRound -serviceAddr 127.0.0.1:8935 -orchAddr 0.0.0.0:8935
 ```
 
 * Once the orchestrator is running, hold `<CTRL>` and type `<A>` then `<D>` to leave the screen session running in the background.

--- a/testnet-rinkeby-b_ot.md
+++ b/testnet-rinkeby-b_ot.md
@@ -45,7 +45,7 @@ Hit `<ENTER>` a few times to get to a command prompt.
 * Run the following command to start the orchestrator / transcoder:
 
 ```bash
-./livepeer -v 99 -network rinkeby -orchestrator -transcoder -pricePerUnit 1 -nvidia 0 -initializeRound true -serviceAddr 127.0.0.1:8935
+./livepeer -v 99 -network rinkeby -orchestrator -transcoder -pricePerUnit 1 -nvidia 0 -initializeRound -serviceAddr 127.0.0.1:8935
 ```
 
 * Once the orchestrator / transcoder is running, hold `<CTRL>` and type `<A>` then `<D>` to leave the screen session running in the background.

--- a/ubuntu/cuda-docker-compose-setup-b_o_t-rinkeby.md
+++ b/ubuntu/cuda-docker-compose-setup-b_o_t-rinkeby.md
@@ -75,7 +75,7 @@ version: '3.5'
 services:
   orchestrator:
     image: livepeer/go-livepeer:master
-    command: '-orchestrator -network rinkeby -orchSecret /secret.txt -serviceAddr orchestrator:8935 -orchAddr 0.0.0.0 -pricePerUnit 1 -initializeRound true'
+    command: '-orchestrator -network rinkeby -orchSecret /secret.txt -serviceAddr orchestrator:8935 -orchAddr 0.0.0.0 -pricePerUnit 1 -initializeRound'
     ports:
       - 7935:7935
       - 8935:8935
@@ -146,7 +146,7 @@ echo MyEthPassPhrase > passphrase_orch.txt
 * Edit the `docker-compose.yml` to add the `ethPassword` argument to the orchestrator command line.  The new command should look like this:
 
 ```bash
--orchestrator -network rinkeby -orchSecret /secret.txt -serviceAddr orchestrator:8935 -orchAddr 0.0.0.0 -pricePerUnit 1 -initializeRound true -ethPassword=/root/pw.txt
+-orchestrator -network rinkeby -orchSecret /secret.txt -serviceAddr orchestrator:8935 -orchAddr 0.0.0.0 -pricePerUnit 1 -initializeRound -ethPassword=/root/pw.txt
 ```
 
 * Next, we must initialize an ethereum account for the broadcaster.  Bring up the broadcaster using interactive mode:

--- a/ubuntu/cuda-docker-compose-setup-b_ot-rinkeby.md
+++ b/ubuntu/cuda-docker-compose-setup-b_ot-rinkeby.md
@@ -75,7 +75,7 @@ version: '3.5'
 services:
   orchtran:
     image: livepeer/go-livepeer:master
-    command: '-network rinkeby -orchestrator -transcoder -serviceAddr orchtran:8935 -orchAddr 0.0.0.0 -initializeRound true -pricePerUnit 1 -nvidia 0'
+    command: '-network rinkeby -orchestrator -transcoder -serviceAddr orchtran:8935 -orchAddr 0.0.0.0 -initializeRound -pricePerUnit 1 -nvidia 0'
     ports:
       - 7935:7935
       - 8935:8935
@@ -130,7 +130,7 @@ echo MyEthPassPhrase > passphrase_orch.txt
 * Edit the `docker-compose.yml` to add the `ethPassword` argument to the orchtran command line.  The new command should look like this:
 
 ```bash
--network rinkeby -orchestrator -transcoder -serviceAddr orchestrator:8935 -orchAddr 0.0.0.0 -initializeRound true -pricePerUnit 1 -nvidia 0 -ethPassword=/root/pw.txt
+-network rinkeby -orchestrator -transcoder -serviceAddr orchestrator:8935 -orchAddr 0.0.0.0 -initializeRound -pricePerUnit 1 -nvidia 0 -ethPassword=/root/pw.txt
 ```
 
 * Next, we must initialize an ethereum account for the broadcaster.  Bring up the broadcaster using interactive mode:


### PR DESCRIPTION
from [this comment](https://github.com/livepeer/go-livepeer/issues/1294#issuecomment-573433770): 

> The CLI flag syntax -initializeRound true is actually not permitted by the Go flag package since -initializeRound is a boolean flag. In order to set the value for this flag you have to use the syntax -initializeRound or -initializeRound=true.

> For now, we can make sure that docs that describe commands containing boolean flags always use permitted syntax for the boolean flags (i.e. -flag=true or -flag).

This PR changes the syntax for the boolean `-initializeRound` flag to simply be `-initializeRound` when the value is true instead of `initializeRound true` (invalid)  and `initializeRound=true`